### PR TITLE
feat: allow options as object

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Which will transform it into:
 </article>
 ```
 
+You can also pass in an object:
+
+```js
+rehype()
+  .use(urls, { transform: removeBaseUrl })
+  .process(input, handleOutput)
+```
+
 ### Mutate nodes
 
 It's also possible to mutate the URL nodes directly. This example will add `target="_blank"` to any external links:

--- a/index.js
+++ b/index.js
@@ -3,8 +3,11 @@ var url = require('url')
 var opt = require('stdopt')
 var visit = require('unist-util-visit')
 
-module.exports = function transform (fn) {
-  fn = fn || function () {}
+module.exports = function transform (options) {
+  if (typeof options === 'function') {
+    options = { transform: options }
+  }
+  options.transform = options.transform || function () {}
 
   return function transformer (tree) {
     visit(tree, 'element', function (node) {
@@ -16,7 +19,7 @@ module.exports = function transform (fn) {
   function modify (node, prop) {
     if (has(node, prop)) {
       var obj = url.parse(node.properties[prop])
-      var res = opt(fn(obj, node)).or(obj).value()
+      var res = opt(options.transform(obj, node)).or(obj).value()
       node.properties[prop] = url.format(res)
     }
   }

--- a/test.js
+++ b/test.js
@@ -24,6 +24,16 @@ tape('mutate', t => {
   t.end()
 })
 
+tape('option object', t => {
+  var href = '<a href="http://example.com/page.html">text</a>'
+  var src = '<img src="http://example.com/image.jpg">'
+  var p = rehype().use(urls, { transform: url => url.path }).freeze()
+
+  t.equal(p.processSync(href).contents, wrap('<a href="/page.html">text</a>'), 'return href string')
+  t.equal(p.processSync(src).contents, wrap('<img src="/image.jpg">'), 'return src string')
+  t.end()
+})
+
 function wrap (html) {
   return `<html><head></head><body>${html}</body></html>`
 }


### PR DESCRIPTION
Some libraries like [@nuxt/content](https://www.npmjs.com/package/@nuxt/content) only allow options of rehype plugins as an object, so this PR allows to also pass an object with a `transform` property.